### PR TITLE
Release: v0.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ iex> TimeMachinex.utc_now
 New Features:
 - `add/2`, `add/3`
 
+Fixes:
+- Allow negative years in ISO 8601.
+
 Cleanup:
 - `truncate/2`
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ iex> TimeMachinex.utc_now
 ### v0.0.8 (2019-12-??)
 
 New Features:
+- `add/2`, `add/3`
 
 Cleanup:
 - `truncate/2`
@@ -184,7 +185,7 @@ Additional:
 - Integrations
   - `:fixtures`
 - Release 0.0.8
-  - Add / Diff
+  - Diff
   - Benchmarks
 - Release 0.0.9
   - To Unix

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ iex> TimeMachinex.utc_now
 
 New Features:
 - `add/2`, `add/3`
+- `diff/2`, `diff3`
 
 Fixes:
 - Allow negative years in ISO 8601.

--- a/bench/add.exs
+++ b/bench/add.exs
@@ -1,0 +1,18 @@
+now_datetime = DateTime.utc_now()
+now_naive_datetime = NaiveDateTime.utc_now()
+now_utc_datetime = UTCDateTime.utc_now()
+
+Benchee.run(
+  %{
+    "DateTime" => fn {amount, unit} -> DateTime.add(now_datetime, amount, unit) end,
+    "NaiveDateTime" => fn {amount, unit} ->
+      NaiveDateTime.add(now_naive_datetime, amount, unit)
+    end,
+    "UTCDateTime" => fn {amount, unit} -> UTCDateTime.add(now_utc_datetime, amount, unit) end
+  },
+  inputs: %{
+    "nanosecond" => {8392, :nanosecond},
+    "millisecond" => {8392, :millisecond},
+    "seconds" => {8392, :second}
+  }
+)

--- a/bench/diff.exs
+++ b/bench/diff.exs
@@ -1,0 +1,20 @@
+use UTCDateTime
+
+Benchee.run(
+  %{
+    "DateTime" => fn unit ->
+      DateTime.diff(~U[2014-10-02 00:29:12Z], ~U[2014-10-02 00:29:10Z], unit)
+    end,
+    "NaiveDateTime" => fn unit ->
+      NaiveDateTime.diff(~N[2014-10-02 00:29:12], ~N[2014-10-02 00:29:10], unit)
+    end,
+    "UTCDateTime" => fn unit ->
+      UTCDateTime.diff(~Z[2014-10-02 00:29:12], ~Z[2014-10-02 00:29:10], unit)
+    end
+  },
+  inputs: %{
+    "nanoseconds" => :nanosecond,
+    "milliseconds" => :millisecond,
+    "seconds" => :second
+  }
+)

--- a/lib/utc_datetime.ex
+++ b/lib/utc_datetime.ex
@@ -1288,6 +1288,72 @@ defmodule UTCDateTime do
   end
 
   @doc ~S"""
+  Subtracts `utc_datetime1` from `utc_datetime2`.
+
+  The answer can be returned in any `unit` available from `t:System.time_unit/0`.
+
+  This function returns the difference in seconds where seconds are measured
+  according to `Calendar.ISO`.
+
+  ## Examples
+
+  ```elixir
+  iex> UTCDateTime.diff(~Z[2014-10-02 00:29:12], ~Z[2014-10-02 00:29:10])
+  2
+  iex> UTCDateTime.diff(~Z[2014-10-02 00:29:12], ~Z[2014-10-02 00:29:10], :microsecond)
+  2_000_000
+  iex> UTCDateTime.diff(~Z[2014-10-02 00:29:10.042], ~Z[2014-10-02 00:29:10.021], :millisecond)
+  21
+  iex> UTCDateTime.diff(~Z[2014-10-02 00:29:10], ~Z[2014-10-02 00:29:12])
+  -2
+  iex> UTCDateTime.diff(~Z[-0001-10-02 00:29:10], ~Z[-0001-10-02 00:29:12])
+  -2
+  ```
+
+  ```elixir
+  # to Gregorian seconds
+  iex> UTCDateTime.diff(~Z[2014-10-02 00:29:10], ~Z[0000-01-01 00:00:00])
+  63579428950
+  ```
+  """
+  @spec diff(UTCDateTime.t(), UTCDateTime.t(), System.time_unit()) :: integer
+  def diff(utc_datetime1, utc_datetime2, unit \\ :second)
+
+  def diff(
+        %__MODULE__{
+          year: year1,
+          month: month1,
+          day: day1,
+          hour: hour1,
+          minute: minute1,
+          second: second1,
+          microsecond: microsecond1
+        },
+        %__MODULE__{
+          year: year2,
+          month: month2,
+          day: day2,
+          hour: hour2,
+          minute: minute2,
+          second: second2,
+          microsecond: microsecond2
+        },
+        unit
+      ) do
+    units1 =
+      year1
+      |> ISO.naive_datetime_to_iso_days(month1, day1, hour1, minute1, second1, microsecond1)
+      |> ISO.iso_days_to_unit(unit)
+
+    units2 =
+      year2
+      |> ISO.naive_datetime_to_iso_days(month2, day2, hour2, minute2, second2, microsecond2)
+      |> ISO.iso_days_to_unit(unit)
+
+    units1 - units2
+  end
+
+  @doc ~S"""
   Returns the given `utc_datetime` with the microsecond field truncated to the
   given precision (`:microsecond`, `:millisecond` or `:second`).
 

--- a/lib/utc_datetime.ex
+++ b/lib/utc_datetime.ex
@@ -824,6 +824,13 @@ defmodule UTCDateTime do
 
   @sep_iso8601 [?T, ?\s, ?t]
 
+  def from_iso8601(string)
+
+  def from_iso8601("-" <> string) do
+    with {:ok, utc_datetime = %{year: y}} <- from_iso8601(string),
+         do: {:ok, %{utc_datetime | year: -y}}
+  end
+
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def from_iso8601(string) do
     with <<unquote(match_date), sep, unquote(match_time), rest::binary>> <- string,


### PR DESCRIPTION
New Features:
- `add/2`, `add/3`
- `diff/2`, `diff3`

Fixes:
- Allow negative years in ISO 8601.

Cleanup:
- `truncate/2`